### PR TITLE
Fix missing return value in getBemf() method of Haptic_Driver.cpp

### DIFF
--- a/src/Haptic_Driver.cpp
+++ b/src/Haptic_Driver.cpp
@@ -499,6 +499,8 @@ float Haptic_Driver::getBemf()
     case 0x03:
         return 49.9;
     }
+
+    return 0.0;
 }
 
 void Haptic_Driver::createHeader(uint8_t numSnippets, uint8_t numSequences)


### PR DESCRIPTION
## Problem

While trying the I2C_mode example using Arduino IDE 2.3.4, I encountered the following error during compilation:

```
/Users/takahiro/Documents/Arduino/libraries/SparkFun_Qwiic_Haptic_Driver_DA7280_Library/src/Haptic_Driver.cpp: In member function 'float Haptic_Driver::getBemf()':
/Users/takahiro/Documents/Arduino/libraries/SparkFun_Qwiic_Haptic_Driver_DA7280_Library/src/Haptic_Driver.cpp:502:1: error: control reaches end of non-void function [-Werror=return-type]
  502 | }
      | ^
cc1plus: some warnings being treated as errors

exit status 1

Compilation error: exit status 1
```

It seems the issue is that the getBemf() method not having a default return value, even though it is declared to return a float. The error occurs even when I only import "Haptic_Driver.h" without using the library in my code, which suggests it is an issue with the library's implementation rather than usage.

## Fix
I added a return 0.0 at the end of the method as a workaround, and the example compiled successfully. 

## Concerns
I am unsure whether returning 0.0 is appropriate, as I am not familiar with the intended behavior of the getBemf() method. If another value is more appropriate, I am open to suggestions.